### PR TITLE
Fix deb building after prost library update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM prekucki/ya-build-deb
+RUN apt-get update && apt-get install -y \
+    cmake \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
Prost no longer provides built binaries. They must be compile using cmake, which was lacking in this dockerfile